### PR TITLE
Set the 'initial heap-size' to half of

### DIFF
--- a/utils/java-dynamic-memory-opts
+++ b/utils/java-dynamic-memory-opts
@@ -16,5 +16,6 @@ fi
 
 MEM_TOTAL_KB=$(cat /proc/meminfo | grep MemTotal | awk '{print $2}')
 MEM_JAVA_KB=$(($MEM_TOTAL_KB * $MEM_JAVA_PERCENT / 100))
+MIN_MEM_JAVA_KB=$(($MEM_JAVA_KB / 2))
 
-echo "-Xmx${MEM_JAVA_KB}k"
+echo "-Xms${MIN_MEM_JAVA_KB}k -Xmx${MEM_JAVA_KB}k"


### PR DESCRIPTION
'maximum heap-size'. To avoid OOME on startup.
fixes #6
