### PR TITLE
allow overwriting MEM_TOTAL_KB for Kubernetes

### DIFF
--- a/utils/java-dynamic-memory-opts
+++ b/utils/java-dynamic-memory-opts
@@ -14,7 +14,11 @@ if [ -z "$MEM_JAVA_PERCENT" ]; then
     fi
 fi
 
-MEM_TOTAL_KB=$(cat /proc/meminfo | grep MemTotal | awk '{print $2}')
+# MEM_TOTAL_KB can be set from the outside, this is important for container-based infrastructure:
+# /proc/meminfo would return the host/node capacity and not the container's limit
+if [ -z "$MEM_TOTAL_KB" ]; then
+    MEM_TOTAL_KB=$(cat /proc/meminfo | grep MemTotal | awk '{print $2}')
+fi
 MEM_JAVA_KB=$(($MEM_TOTAL_KB * $MEM_JAVA_PERCENT / 100))
 
 echo "-Xmx${MEM_JAVA_KB}k"


### PR DESCRIPTION
`MEM_TOTAL_KB` can be set from the outside, this is important for container-based infrastructure:
`/proc/meminfo` would return the host/node capacity and not the container's limit.

Example usage in Kubernetes:

```yaml
     env:
            - name: MEM_TOTAL_KB
              valueFrom:
                resourceFieldRef:
                  resource: limits.memory
                  divisor: 1Ki
