### PR TITLE
use Docker --squash option

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -2,15 +2,24 @@ build_steps:
     - desc: 'Install required build software'
       cmd: 'apt-get install -y make git apt-transport-https ca-certificates curl'
     - desc: 'Install Docker'
-      cmd: 'curl -sSL https://get.docker.com/ | sh'
-    - desc: 'Install docker-squash'
-      cmd: 'curl -sL https://github.com/jwilder/docker-squash/releases/download/v0.2.0/docker-squash-linux-amd64-v0.2.0.tar.gz | tar -xvz'
+      cmd: |
+        # enable experimental features (--squash)
+        mkdir -p /etc/systemd/system/docker.service.d
+        cat << EOF > /etc/systemd/system/docker.service.d/docker.conf
+        [Service]
+        ExecStart=
+        ExecStart=/usr/bin/dockerd -H fd:// --experimental=true
+        EOF
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+        apt-key fingerprint 0EBFCD88
+        add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        apt-get update
+        apt-get install -y docker-ce
+        systemctl status docker
     - desc: 'Build'
       cmd: |
         image=openjdk-temp:${CDP_BUILD_VERSION}
-        docker build -t $image .
-        # squash to one layer
-        docker save $image | ./docker-squash -verbose -from root -t $image | docker load
+        docker build -t $image --squash .
         sed -i "s,UNTESTED,$image,g" Dockerfile.test
         docker build -t $image-test -f Dockerfile.test .
         # get current Java version
@@ -19,5 +28,9 @@ build_steps:
         # e.g. 'openjdk version "1.8.0_131"'
         version=$(echo "$out" | grep 'openjdk version' | tr -d '"' | tr '_' '-' | awk '{ print $3 }')
         release=registry-write.opensource.zalan.do/stups/openjdk:$version-${CDP_TARGET_BRANCH_COUNTER}
-        docker tag $image $release
-        docker push $release
+        IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
+        if [[ $CDP_TARGET_BRANCH == "master" && ${IS_PR_BUILD} != "true" ]]
+        then
+            docker tag $image $release
+            docker push $release
+        fi


### PR DESCRIPTION
The `--squash` option seems to work, I tried it with https://github.com/zalando-stups/docker-ubuntu :

Without `--squash`:
```
~ $ docker history registry.opensource.zalan.do/stups/ubuntu:16.04.2-2
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
fd2c8bf1c1b4        14 hours ago        /bin/sh -c purge.sh                             0 B                 
<missing>           14 hours ago        /bin/sh -c #(nop) COPY file:85a8d1fbb7f72f...   300 B               
<missing>           14 hours ago        /bin/sh -c update-ca-certificates               311 kB              
<missing>           14 hours ago        /bin/sh -c for CERT in /tmp/rds-ca/xx*; do...   21.7 kB             
<missing>           14 hours ago        /bin/sh -c cd /tmp/rds-ca && csplit -sz aw...   21.7 kB             
<missing>           14 hours ago        /bin/sh -c mkdir /tmp/rds-ca &&     curl h...   21.7 kB             
<missing>           14 hours ago        /bin/sh -c curl https://secure-static.ztat...   7.58 kB             
<missing>           14 hours ago        /bin/sh -c curl https://secure-static.ztat...   7.59 kB             
<missing>           14 hours ago        /bin/sh -c #(nop)  ENV LANG=en_US.UTF-8         0 B                 
<missing>           14 hours ago        /bin/sh -c apt-get update     && apt-get d...   63.6 MB             
<missing>           14 hours ago        /bin/sh -c #(nop)  MAINTAINER Zalando SE        0 B                 
<missing>           13 days ago         /bin/sh -c #(nop)  CMD ["/bin/bash"]            0 B                 
<missing>           13 days ago         /bin/sh -c mkdir -p /run/systemd && echo '...   7 B                 
<missing>           13 days ago         /bin/sh -c sed -i 's/^#\s*\(deb.*universe\...   2.76 kB             
<missing>           13 days ago         /bin/sh -c rm -rf /var/lib/apt/lists/*          0 B                 
<missing>           13 days ago         /bin/sh -c set -xe   && echo '#!/bin/sh' >...   745 B               
<missing>           13 days ago         /bin/sh -c #(nop) ADD file:5aff8c59a707833...   118 MB   
```

With `--squash`:
```           
~ $ docker history registry.opensource.zalan.do/stups/ubuntu:16.04.2-4
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
fa6dfcaf6b9b        54 minutes ago                                                      62.3 MB             merge sha256:af582c46716679bcf9809be6bdd54770453734e680a353216c4f32e30e42f078 to sha256:7b9b13f7b9c086adfb6be4d2d264f90f16b4d1d5b3ab9f955caa728c3675c8a2
<missing>           54 minutes ago      /bin/sh -c purge.sh                             0 B                 
<missing>           54 minutes ago      /bin/sh -c #(nop) COPY file:85a8d1fbb7f72f...   0 B                 
<missing>           54 minutes ago      /bin/sh -c update-ca-certificates               0 B                 
<missing>           54 minutes ago      /bin/sh -c for CERT in /tmp/rds-ca/xx*; do...   0 B                 
<missing>           54 minutes ago      /bin/sh -c cd /tmp/rds-ca && csplit -sz aw...   0 B                 
<missing>           54 minutes ago      /bin/sh -c mkdir /tmp/rds-ca &&     curl h...   0 B                 
<missing>           54 minutes ago      /bin/sh -c curl https://secure-static.ztat...   0 B                 
<missing>           54 minutes ago      /bin/sh -c curl https://secure-static.ztat...   0 B                 
<missing>           54 minutes ago      /bin/sh -c #(nop)  ENV LANG=en_US.UTF-8         0 B                 
<missing>           54 minutes ago      /bin/sh -c apt-get update     && apt-get d...   0 B                 
<missing>           55 minutes ago      /bin/sh -c #(nop)  MAINTAINER Zalando SE        0 B                 
<missing>           13 days ago         /bin/sh -c #(nop)  CMD ["/bin/bash"]            0 B                 
<missing>           13 days ago         /bin/sh -c mkdir -p /run/systemd && echo '...   7 B                 
<missing>           13 days ago         /bin/sh -c sed -i 's/^#\s*\(deb.*universe\...   2.76 kB             
<missing>           13 days ago         /bin/sh -c rm -rf /var/lib/apt/lists/*          0 B                 
<missing>           13 days ago         /bin/sh -c set -xe   && echo '#!/bin/sh' >...   745 B               
<missing>           13 days ago         /bin/sh -c #(nop) ADD file:5aff8c59a707833...   118 MB              
