### PR TITLE
fix install on Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.opensource.zalan.do/stups/ubuntu:latest
 MAINTAINER Zalando SE
 
-RUN apt-get update && apt-get install --no-install-recommends -y openjdk-8-jdk
+# mkdir required because of https://github.com/resin-io-library/base-images/issues/273
+RUN mkdir /usr/share/man/man1 && apt-get update && apt-get install --no-install-recommends -y openjdk-8-jdk
 
 # Note: Zalando CA should have been automatically imported into Java trust store by Debian
 


### PR DESCRIPTION
OpenJDK install fails because of a missing "man" directory..

See also: https://github.com/resin-io-library/base-images/issues/273

> Setting up openjdk-8-jre-headless:amd64 (8u162-b12-1) ...
> update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/rmid to provide /usr/bin/rmid (rmid) in auto mode
> update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
> dpkg: error processing package openjdk-8-jre-headless:amd64 (--configure):
>  installed openjdk-8-jre-headless:amd64 package post-installation script subprocess returned error exit status 2
> dpkg: dependency problems prevent configuration of openjdk-8-jdk-headless:amd64:
>  openjdk-8-jdk-headless:amd64 depends on openjdk-8-jre-headless (= 8u162-b12-1); however:
>   Package openjdk-8-jre-headless:amd64 is not configured yet.
> 
> dpkg: error processing package openjdk-8-jdk-headless:amd64 (--configure):
>  dependency problems - leaving unconfigured
> dpkg: dependency problems prevent configuration of openjdk-8-jdk:amd64:
>  openjdk-8-jdk:amd64 depends on openjdk-8-jdk-headless (= 8u162-b12-1); however:
>   Package openjdk-8-jdk-headless:amd64 is not configured yet.
> 
> dpkg: error processing package openjdk-8-jdk:amd64 (--configure):
>  dependency problems - leaving unconfigured
> dpkg: dependency problems prevent configuration of openjdk-8-jre:amd64:
>  openjdk-8-jre:amd64 depends on openjdk-8-jre-headless (= 8u162-b12-1); however:
>   Package openjdk-8-jre-headless:amd64 is not configured yet.
> 
> dpkg: error processing package openjdk-8-jre:amd64 (--configure):
>  dependency problems - leaving unconfigured
> Processing triggers for libc-bin (2.27-3ubuntu1) ...
> Processing triggers for libgdk-pixbuf2.0-0:amd64 (2.36.11-2) ...
> Errors were encountered while processing:
>  openjdk-8-jre-headless:amd64
>  openjdk-8-jdk-headless:amd64
>  openjdk-8-jdk:amd64
>  openjdk-8-jre:amd64
> E: Sub-process /usr/bin/dpkg returned an error code (1)
> 