### PR TITLE
Possibility to set -Xms equal to -Xmx

### DIFF
--- a/utils/java-dynamic-memory-opts
+++ b/utils/java-dynamic-memory-opts
@@ -21,4 +21,8 @@ if [ -z "$MEM_TOTAL_KB" ]; then
 fi
 MEM_JAVA_KB=$(($MEM_TOTAL_KB * $MEM_JAVA_PERCENT / 100))
 
-echo "-Xmx${MEM_JAVA_KB}k"
+if [ -z "MEM_JAVA_XMX_EQ_XMS" ]; then
+    echo "-Xmx${MEM_JAVA_KB}k"
+else
+    echo "-Xmx${MEM_JAVA_KB}k -Xms${MEM_JAVA_KB}k"
+fi

--- a/utils/java-dynamic-memory-opts
+++ b/utils/java-dynamic-memory-opts
@@ -21,7 +21,7 @@ if [ -z "$MEM_TOTAL_KB" ]; then
 fi
 MEM_JAVA_KB=$(($MEM_TOTAL_KB * $MEM_JAVA_PERCENT / 100))
 
-if [ -z "MEM_JAVA_XMX_EQ_XMS" ]; then
+if [ -z "$MEM_JAVA_XMX_EQ_XMS" ]; then
     echo "-Xmx${MEM_JAVA_KB}k"
 else
     echo "-Xmx${MEM_JAVA_KB}k -Xms${MEM_JAVA_KB}k"


### PR DESCRIPTION
https://developer.jboss.org/thread/149559?_sscc=t

https://stackoverflow.com/questions/43651167/is-there-any-advantage-in-setting-xms-and-xmx-to-the-same-value

TLDR:
Java will increase heap size until it reaches `Xmx`. But you can allocate maximum amount of memory from the start (`Xms` option) for performance reasons (e.g. avoid garbage collection).