### PR TITLE
Set JAVA_HOME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN for i in /etc/ssl/certs/*.pem; do yes | keytool -importcert -alias $i -keyst
 RUN keytool -list -keystore /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -storepass changeit | grep zalando
 
 ADD utils /java-utils
-ENV PATH ${PATH}:/${JAVA_HOME}/bin:/java-utils
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV PATH ${PATH}:${JAVA_HOME}/bin:/java-utils
 
 CMD ["java", "-version"]
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,6 @@ Build and test the image like that:
 
 .. code-block:: bash
 
-    $ sed -i 's/UPSTREAM/15.10-11/g' Dockerfile
     $ docker build -t openjdk:local .
     $ sed -i 's/UNTESTED/openjdk:local/g' Dockerfile.test
     $ docker build -t openjdk-test:local -f Dockerfile.test .

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,9 @@ javac catest/CATest.java || exit $?
 
 echo "Running tests..."
 
+${JAVA_HOME+"false"} && ENV_RESULT=1 || ENV_RESULT=0
+[ $ENV_RESULT -eq 0 ] && echo "TEST ENV: OK (JAVA_HOME is set)" || echo "TEST ENV: FAILED (JAVA_HOME not set)"
+
 java jcetest.JCETest
 JCE_RESULT=$?
 [ $JCE_RESULT -eq 0 ] && echo "TEST JCE: OK (JCE is unlimited)" || echo "TEST JCE: FAILED (JCE is restricted)"
@@ -21,7 +24,7 @@ java catest.CATest
 CA_RESULT=$?
 [ $CA_RESULT -eq 0 ] && echo "TEST CA: OK (CA is trusted)" || echo "TEST CA: FAILED (CA is not trusted)"
 
-if [ $JCE_RESULT -eq 0 -a $SSL_RESULT -eq 0 -a $CA_RESULT -eq 0 ]; then
+if [ $ENV_RESULT -eq 0 -a $JCE_RESULT -eq 0 -a $SSL_RESULT -eq 0 -a $CA_RESULT -eq 0 ]; then
 	echo "Image verified!"
 	exit 0
 else


### PR DESCRIPTION
As the installation of openjdk doesn't set it, we have to set `JAVA_HOME` manually.